### PR TITLE
Update to match standard Meteor login and Account token storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## [Unreleased]
+
+#### Warning - Potentially breaking change
+- Restivus used to store the account login token in the user document: `services.resume.loginTokens.token`
+- Restivus now stores the account login token as a hashed token, in the user document: `services.resume.loginTokens.hashedToken`
+- This means that all clients consuming a Restivus API will need to reauthenticate with their 
+  username/email and password after this update, as their existing tokens will be rendered invalid.
+
+#### Changed
+- Update default auth endpoints to match current Accounts token storage (see #79)
+- Return "Unauthorized" for failed authentication
+- To match Meteor, store password token as `hashedToken`
+- Add unit tests for authentication
+  
+
 ## [v0.6.6] - 2015-05-25
 
 #### Fixed

--- a/README.md
+++ b/README.md
@@ -263,8 +263,8 @@ but all properties are optional):
 ##### `auth`
 - _Object_
   - `token`  _String_
-    - Default: `'services.resume.loginTokens.token'`
-    - The path to the auth token in the `Meteor.user` document. This location will be checked for a
+    - Default: `'services.resume.loginTokens.hashedToken'`
+    - The path to the hashed auth token in the `Meteor.user` document. This location will be checked for a
       matching token if one is returned in `auth.user()`.
   - `user`  _Function_
     - Default: Get user ID and auth token from `X-User-Id` and `X-Auth-Token` headers
@@ -286,7 +286,8 @@ but all properties are optional):
       - Partial auth
         - `userId`: The ID of the user being authenticated
         - `token`: The auth token to be verified
-        - If both a `userId` and `token` are returned, authentication will succeed if the `token`
+        - If both a `userId` and `token` are returned, Restivus will hash the token, then,
+          authentication will succeed if the `hashedToken`
           exists in the given `Meteor.user` document at the location specified in `auth.token`
       - Complete auth
         - `user`: The fully authenticated `Meteor.user`

--- a/lib/auth.coffee
+++ b/lib/auth.coffee
@@ -35,7 +35,7 @@ getUserQuerySelector = (user) ->
 ###
 @Auth.loginWithPassword = (user, password) ->
   if not user or not password
-    return undefined # TODO: Should we throw a more descriptive error here, or is that insecure?
+    throw new Meteor.Error 403, 'Unauthorized'
 
   # Validate the login input types
   check user, userValidator
@@ -46,17 +46,18 @@ getUserQuerySelector = (user) ->
   authenticatingUser = Meteor.users.findOne(authenticatingUserSelector)
 
   if not authenticatingUser
-    throw new Meteor.Error 403, 'User not found'
+    throw new Meteor.Error 403, 'Unauthorized'
   if not authenticatingUser.services?.password
-    throw new Meteor.Error 403, 'User has no password set'
+    throw new Meteor.Error 403, 'Unauthorized'
 
   # Authenticate the user's password
   passwordVerification = Accounts._checkPassword authenticatingUser, password
   if passwordVerification.error
-    throw new Meteor.Error 403, 'Incorrect password'
+    throw new Meteor.Error 403, 'Unauthorized'
 
   # Add a new auth token to the user's account
   authToken = Accounts._generateStampedLoginToken()
-  Meteor.users.update authenticatingUser._id, {$push: {'services.resume.loginTokens': authToken}}
+  hashedToken = Accounts._hashLoginToken authToken.token
+  Accounts._insertHashedLoginToken authenticatingUser._id, {hashedToken}
 
   return {authToken: authToken.token, userId: authenticatingUser._id}

--- a/lib/restivus.coffee
+++ b/lib/restivus.coffee
@@ -9,7 +9,7 @@ class @Restivus
       version: 1
       prettyJson: false
       auth:
-        token: 'services.resume.loginTokens.token'
+        token: 'services.resume.loginTokens.hashedToken'
         user: ->
           userId: @request.headers['x-user-id']
           token: @request.headers['x-auth-token']
@@ -289,10 +289,12 @@ class @Restivus
         # Get the authenticated user
         # TODO: Consider returning the user in Auth.loginWithPassword(), instead of fetching it again here
         if auth.userId and auth.authToken
+          searchQuery = {}
+          searchQuery[self.config.auth.token] = Accounts._hashLoginToken auth.authToken
           @user = Meteor.users.findOne
             '_id': auth.userId
-            'services.resume.loginTokens.token': auth.authToken
-          @userId = @user._id
+            searchQuery
+          @userId = @user?._id
 
         # TODO: Add any return data to response as data.extra
         # Call the login hook with the authenticated user attached
@@ -309,11 +311,20 @@ class @Restivus
       get: ->
         # Remove the given auth token from the user's account
         authToken = @request.headers['x-auth-token']
-        Meteor.users.update @user._id, {$pull: {'services.resume.loginTokens': {token: authToken}}}
+        hashedToken = Accounts._hashLoginToken authToken
+        tokenLocation = self.config.auth.token
+        index = tokenLocation.lastIndexOf '.'
+        tokenPath = tokenLocation.substring 0, index
+        tokenFieldName = tokenLocation.substring index + 1
+        tokenToRemove = {}
+        tokenToRemove[tokenFieldName] = hashedToken
+        tokenRemovalQuery = {}
+        tokenRemovalQuery[tokenPath] = tokenToRemove
+        Meteor.users.update @user._id, {$pull: tokenRemovalQuery}
 
         # TODO: Add any return data to response as data.extra
         # Call the logout hook with the logged out user attached
-        self.config.onLoggedOut.call this
+        self.config.onLoggedOut?.call this
 
         {status: "success", data: message: 'You\'ve been logged out!'}
 

--- a/lib/route.coffee
+++ b/lib/route.coffee
@@ -159,10 +159,10 @@ class @Route
     auth = @api.config.auth.user.call(endpointContext)
 
     # Get the user from the database
-    if not auth?.user and auth?.userId and auth?.token
+    if auth?.userId and auth?.token and not auth?.user
       userSelector = {}
       userSelector._id = auth.userId
-      userSelector[@api.config.auth.token] = auth.token
+      userSelector[@api.config.auth.token] = Accounts._hashLoginToken auth.token
       auth.user = Meteor.users.findOne userSelector
 
     # Attach the user and their ID to the context if the authentication was successful

--- a/package.js
+++ b/package.js
@@ -15,6 +15,7 @@ Package.onUse(function (api) {
   api.use('coffeescript');
   api.use('underscore');
   api.use('iron:router@1.0.6');
+  api.use('accounts-base');
 
   // Package files
   api.addFiles('lib/restivus.coffee', 'server');
@@ -33,7 +34,10 @@ Package.onTest(function (api) {
   api.use('http');
   api.use('coffeescript');
   api.use('peterellisjones:describe');
+  api.use('accounts-base');
+  api.use('accounts-password');
 
   api.addFiles('test/route_tests.coffee', 'server');
   api.addFiles('test/api_tests.coffee', 'server');
+  api.addFiles('test/authentication_tests.coffee', 'server');
 });

--- a/test/api_tests.coffee
+++ b/test/api_tests.coffee
@@ -6,7 +6,7 @@ Meteor.startup ->
         test.equal Restivus.config.apiPath, 'api/'
         test.isFalse Restivus.config.useAuth
         test.isFalse Restivus.config.prettyJson
-        test.equal Restivus.config.auth.token, 'services.resume.loginTokens.token'
+        test.equal Restivus.config.auth.token, 'services.resume.loginTokens.hashedToken'
 
       it 'should allow you to add an unconfigured route', (test) ->
         Restivus.addRoute 'test1', {authRequired: true, roleRequired: 'admin'},
@@ -43,7 +43,11 @@ Meteor.startup ->
         Restivus.configure
           apiPath: 'api/v1'
           useAuth: true
-          auth: token: 'apiKey'
+          auth:
+            token: 'services.resume.loginTokens.hashedToken'
+            user: ->
+              userId: @request.headers['x-user-id']
+              token: @request.headers['x-auth-token']
           defaultHeaders:
             'Content-Type': 'text/json'
             'X-Test-Header': 'test header'
@@ -51,7 +55,7 @@ Meteor.startup ->
         config = Restivus.config
         test.equal config.apiPath, 'api/v1/'
         test.equal config.useAuth, true
-        test.equal config.auth.token, 'apiKey'
+        test.equal config.auth.token, 'services.resume.loginTokens.hashedToken'
         test.equal config.defaultHeaders['Content-Type'], 'text/json'
         test.equal config.defaultHeaders['X-Test-Header'], 'test header'
         test.equal config.defaultHeaders['Access-Control-Allow-Origin'], '*'
@@ -105,7 +109,7 @@ Meteor.startup ->
             description: 'test description'
         response = JSON.parse result.content
         responseData = response.data
-        test.equal result.statusCode, 201
+        test.equal result.statusCode, 200
         test.equal response.status, 'success'
         test.equal responseData.name, 'test name'
         test.equal responseData.description, 'test description'

--- a/test/authentication_tests.coffee
+++ b/test/authentication_tests.coffee
@@ -1,0 +1,100 @@
+Meteor.startup ->
+  describe 'The default authentication endpoints', ->
+    token = null
+    emailLoginToken = null
+    username = 'test'
+    email = 'test@ivus.com'
+    password = 'password'
+
+    # Delete the test account if it's still present
+    Meteor.users.remove username: username
+
+    userId = Accounts.createUser {
+      username: username
+      email
+      password: password
+    }
+
+    it 'should allow a user to login', (test, next) ->
+      HTTP.post Meteor.absoluteUrl('/api/v1/login'), {
+        data: 
+          user: username
+          password: password
+      }, (error, result) ->
+        response = JSON.parse result.content
+        test.equal result.statusCode, 200
+        test.equal response.status, 'success'
+        test.equal response.data.userId, userId
+        test.isTrue response.data.authToken
+
+        # Store the token for later use
+        token = response.data.authToken
+
+        next()
+
+    it 'should allow a user to login again, without affecting the first login', (test, next) ->
+      HTTP.post Meteor.absoluteUrl('/api/v1/login'), {
+        data: 
+          user: email
+          password: password
+      }, (error, result) ->
+        response = JSON.parse result.content
+        test.equal result.statusCode, 200
+        test.equal response.status, 'success'
+        test.equal response.data.userId, userId
+        test.isTrue response.data.authToken
+        test.notEqual token, response.data.authToken
+        
+        # Store the token for later use
+        emailLoginToken = response.data.authToken
+
+        next()
+
+    it 'should not allow a user with wrong password to login', (test, next) ->
+      HTTP.post Meteor.absoluteUrl('/api/v1/login'), {
+        data:
+          user: username
+          password: "NotAllowed"
+      }, (error, result) ->
+        response = JSON.parse result.content
+        test.equal result.statusCode, 403
+        test.equal response.status, 'error'
+
+        next()
+
+    it 'should allow a user to logout', (test, next) ->
+      HTTP.get Meteor.absoluteUrl('/api/v1/logout'), {
+        headers:
+          'X-User-Id': userId
+          'X-Auth-Token': token
+      }, (error, result) ->
+        response = JSON.parse result.content
+        test.equal result.statusCode, 200
+        test.equal response.status, 'success'
+        next()
+
+    it 'should remove the logout token after logging out', (test, next) ->
+      Restivus.addRoute 'prevent-access-after-logout', {authRequired: true},
+        get: -> true
+
+      HTTP.get Meteor.absoluteUrl('/api/v1/prevent-access-after-logout'), {
+        headers:
+          'X-User-Id': userId
+          'X-Auth-Token': token
+      }, (error, result) ->
+        response = JSON.parse result.content
+        test.isTrue error
+        test.equal result.statusCode, 401
+        test.equal response.status, 'error'
+        next()
+
+    it 'should allow a second logged in user to logout', (test, next) ->
+      HTTP.get Meteor.absoluteUrl('/api/v1/logout'), {
+        headers:
+          'X-User-Id': userId
+          'X-Auth-Token': emailLoginToken
+      }, (error, result) ->
+        response = JSON.parse result.content
+        test.equal result.statusCode, 200
+        test.equal response.status, 'success'
+        next()

--- a/test/route_tests.coffee
+++ b/test/route_tests.coffee
@@ -41,4 +41,4 @@ if Meteor.isServer
        test.equal Restivus.config.apiPath, 'api/'
        test.isFalse Restivus.config.useAuth
        test.isFalse Restivus.config.prettyJson
-       test.equal Restivus.config.auth.token, 'services.resume.loginTokens.token'
+       test.equal Restivus.config.auth.token, 'services.resume.loginTokens.hashedToken'


### PR DESCRIPTION
Replaces prior pull request.

Meteor Accounts package uses hashedTokens instead of tokens. I updated the code to
match Accounts package.
Fix for https://github.com/kahmali/meteor-restivus/issues/79