### PR TITLE
Add delay when accessing unauthorized ReST endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Update default auth endpoints to match current Accounts token storage (see #79)
 - Return "Unauthorized" for failed authentication
 - To match Meteor, store password token as `hashedToken`
+- When logging in with bad credentials, randomly delay the response (See #81)
 - Add unit tests for authentication
   
 

--- a/test/authentication_tests.coffee
+++ b/test/authentication_tests.coffee
@@ -50,7 +50,9 @@ Meteor.startup ->
 
         next()
 
-    it 'should not allow a user with wrong password to login', (test, next) ->
+    it 'should not allow a user with wrong password to login and should respond after 500 msec', (test, next) ->
+      # This test should take 500 msec or more. To speed up testing, these two tests have been combined.
+      startTime = new Date()
       HTTP.post Meteor.absoluteUrl('/api/v1/login'), {
         data:
           user: username
@@ -59,6 +61,8 @@ Meteor.startup ->
         response = JSON.parse result.content
         test.equal result.statusCode, 403
         test.equal response.status, 'error'
+        durationInMilliseconds = new Date() - startTime
+        test.isTrue durationInMilliseconds >= 500
 
         next()
 
@@ -73,10 +77,11 @@ Meteor.startup ->
         test.equal response.status, 'success'
         next()
 
-    it 'should remove the logout token after logging out', (test, next) ->
+    it 'should remove the logout token after logging out and should respond after 500 msec', (test, next) ->
       Restivus.addRoute 'prevent-access-after-logout', {authRequired: true},
         get: -> true
-
+      # This test should take 500 msec or more. To speed up testing, these two tests have been combined.
+      startTime = new Date()
       HTTP.get Meteor.absoluteUrl('/api/v1/prevent-access-after-logout'), {
         headers:
           'X-User-Id': userId
@@ -86,6 +91,8 @@ Meteor.startup ->
         test.isTrue error
         test.equal result.statusCode, 401
         test.equal response.status, 'error'
+        durationInMilliseconds = new Date() - startTime
+        test.isTrue durationInMilliseconds >= 500
         next()
 
     it 'should allow a second logged in user to logout', (test, next) ->


### PR DESCRIPTION
I figured I'd create this for #81, now that we are updated.  I don't know what the long term solution is, but this may be a start...

 - This is an initial temporary fix for #81
 - When logging in or accessing a restricted ReST endpoint with invalid credentials,
   the system shall delay before responding.
 - Note that this is not a great fix, since hackers could distribute their requests across CPUs.
 - Resolve #81 

EDIT: We discussed using a middleware solution. Feel free to discard this pull request...