### PR TITLE
Return a 401 instead of 403 for authentication errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,9 @@
 
 #### Changed
 - Update default auth endpoints to match current Accounts token storage (see #79)
-- Return "Unauthorized" for failed authentication
-- To match Meteor, store password token as `hashedToken`
+  - Login token is now stored as `hashedToken` instead of `token`
+- Return `401 Unauthorized` for failed authentication
 - When logging in with bad credentials, randomly delay the response (See #81)
-- Add unit tests for authentication
   
 
 ## [v0.6.6] - 2015-05-25

--- a/lib/auth.coffee
+++ b/lib/auth.coffee
@@ -35,7 +35,7 @@ getUserQuerySelector = (user) ->
 ###
 @Auth.loginWithPassword = (user, password) ->
   if not user or not password
-    throw new Meteor.Error 403, 'Unauthorized'
+    throw new Meteor.Error 401, 'Unauthorized'
 
   # Validate the login input types
   check user, userValidator
@@ -46,14 +46,14 @@ getUserQuerySelector = (user) ->
   authenticatingUser = Meteor.users.findOne(authenticatingUserSelector)
 
   if not authenticatingUser
-    throw new Meteor.Error 403, 'Unauthorized'
+    throw new Meteor.Error 401, 'Unauthorized'
   if not authenticatingUser.services?.password
-    throw new Meteor.Error 403, 'Unauthorized'
+    throw new Meteor.Error 401, 'Unauthorized'
 
   # Authenticate the user's password
   passwordVerification = Accounts._checkPassword authenticatingUser, password
   if passwordVerification.error
-    throw new Meteor.Error 403, 'Unauthorized'
+    throw new Meteor.Error 401, 'Unauthorized'
 
   # Add a new auth token to the user's account
   authToken = Accounts._generateStampedLoginToken()

--- a/test/authentication_tests.coffee
+++ b/test/authentication_tests.coffee
@@ -59,7 +59,7 @@ Meteor.startup ->
           password: "NotAllowed"
       }, (error, result) ->
         response = JSON.parse result.content
-        test.equal result.statusCode, 403
+        test.equal result.statusCode, 401
         test.equal response.status, 'error'
         durationInMilliseconds = new Date() - startTime
         test.isTrue durationInMilliseconds >= 500


### PR DESCRIPTION
@jazeee Feel free to review this while I add in the warning to the README. I tested and it looks good to go on my end, but it couldn't hurt to get a second set of eyes on it. 