### PR TITLE
Ensure auth token is only hashed in default auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 #### Warning - Potentially breaking change
 - Restivus used to store the account login token in the user document: `services.resume.loginTokens.token`
 - Restivus now stores the account login token as a hashed token, in the user document: `services.resume.loginTokens.hashedToken`
-- This means that all clients consuming a Restivus API will need to reauthenticate with their 
+- This means that all clients consuming a Restivus API _with default authentication_ will need to reauthenticate with their 
   username/email and password after this update, as their existing tokens will be rendered invalid.
 
 #### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,12 @@
 
 ## [Unreleased]
 
-#### Warning - Potentially breaking change
-- Restivus used to store the account login token in the user document: `services.resume.loginTokens.token`
-- Restivus now stores the account login token as a hashed token, in the user document: `services.resume.loginTokens.hashedToken`
-- This means that all clients consuming a Restivus API _with default authentication_ will need to reauthenticate with their 
-  username/email and password after this update, as their existing tokens will be rendered invalid.
+**_WARNING!_ Potentially breaking changes! Please be aware when upgrading!**
 
 #### Changed
 - Update default auth endpoints to match current Accounts token storage (see #79)
+  - **_WARNING!_ All clients consuming a Restivus API _with the default authentication_ will need to 
+    reauthenticate after this update**
   - Login token is now stored as `hashedToken` instead of `token`
 - Return `401 Unauthorized` for failed authentication
 - When logging in with bad credentials, randomly delay the response (See #81)
@@ -82,6 +80,7 @@
 
 
 ## [v0.6.1] - 2015-02-19
+
 **_WARNING!_ API-breaking changes! Please be aware when upgrading!**
 
 #### Fixed
@@ -94,6 +93,7 @@
 
 
 ## [v0.6.0] - 2015-02-17
+
 **_WARNING!_ Do not use v0.6.0! Please upgrade to v0.6.1 or above.**
 **_WARNING!_ API-breaking changes! Please be aware when upgrading!**
 

--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ if (Meteor.isServer) {
 
 ## Table of Contents
 
-- [Upgrading from 0.5.x](#upgrading-from-05x)
-- [Upgrading from 0.6.0](#upgrading-from-060)
+- [Upgrading to 0.7.0](#upgrading-to-070)
+- [Upgrading to 0.6.1](#upgrading-to-061)
 - [Terminology](#terminology)
 - [Writing a Restivus API](#writing-a-restivus-api)
   - [Configuration Options](#configuration-options)
@@ -192,7 +192,19 @@ if (Meteor.isServer) {
   - [Change Log](#change-log)
   - [Contributing](#contributing)
 
-## Upgrading from 0.5.x
+## Upgrading to 0.7.0
+
+**_WARNING!_ All clients consuming a Restivus API _with the default authentication_ will need to 
+reauthenticate after this update**
+
+Restivus used to store the account login token in the `Meteor.user` document at 
+`services.resume.loginTokens.token`. Now, to match Meteor's current implementation, the account 
+login token is stored as a hashed token at `services.resume.loginTokens.hashedToken`. This means 
+that all clients using the default authentication in a Restivus API will need to reauthenticate with 
+their username/email and password after this update, as their existing tokens will be rendered 
+invalid.
+
+## Upgrading to 0.6.1
 
 Restivus v0.6.1 brings support for easily generating REST endpoints for your Mongo Collections, and
 with that comes a few API-breaking changes:
@@ -207,17 +219,6 @@ with that comes a few API-breaking changes:
 
 Please see the [change log][restivus-change-log] for more information about the changes between each
 version.
-
-## Upgrading from 0.6.0
-
-**_WARNING!_ Do not use v0.6.0! Please upgrade to v0.6.1 or above.**
-
-v0.6.0 does not allow you to work with existing collections, or access collections created in
-Restivus elsewhere in your app, which is not the intended behavior. Since Meteor expects you to
-construct each collection only once (using `new Mongo.Collection()`), and store that globally,
-Restivus now requires that you pass an existing collection in `Restivus.addCollection()`. Please
-check out the updated section on [defining collection routes](#defining-collection-routes) for a
-detailed breakdown of the parameters to `Restivus.addCollection()`.
 
 ## Terminology
 
@@ -272,7 +273,7 @@ but all properties are optional):
         function() {
           return {
             userId: this.request.headers['x-user-id'],
-            token: this.request.headers['x-auth-token']
+            token: Accounts._hashLoginToken(this.request.headers['x-auth-token'])
           };
         }
         ```

--- a/lib/restivus.coffee
+++ b/lib/restivus.coffee
@@ -12,7 +12,7 @@ class @Restivus
         token: 'services.resume.loginTokens.hashedToken'
         user: ->
           userId: @request.headers['x-user-id']
-          token: @request.headers['x-auth-token']
+          token: Accounts._hashLoginToken @request.headers['x-auth-token']
       onLoggedIn: -> {}
       onLoggedOut: -> {}
       useClientRouter: true

--- a/lib/route.coffee
+++ b/lib/route.coffee
@@ -162,7 +162,7 @@ class @Route
     if auth?.userId and auth?.token and not auth?.user
       userSelector = {}
       userSelector._id = auth.userId
-      userSelector[@api.config.auth.token] = Accounts._hashLoginToken auth.token
+      userSelector[@api.config.auth.token] = auth.token
       auth.user = Meteor.users.findOne userSelector
 
     # Attach the user and their ID to the context if the authentication was successful

--- a/test/api_tests.coffee
+++ b/test/api_tests.coffee
@@ -43,11 +43,6 @@ Meteor.startup ->
         Restivus.configure
           apiPath: 'api/v1'
           useAuth: true
-          auth:
-            token: 'services.resume.loginTokens.hashedToken'
-            user: ->
-              userId: @request.headers['x-user-id']
-              token: @request.headers['x-auth-token']
           defaultHeaders:
             'Content-Type': 'text/json'
             'X-Test-Header': 'test header'


### PR DESCRIPTION
Token hashing is now confined to the default authentication endpoints
and the default user auth function, and will no longer interfere with
the custom auth described in #6. This also means that only clients
consuming a Restivus API with default authentication will require
reauthentication.