### PR TITLE
Ensure that 401 and 403 delay before responding with any information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+#### Fixed
+- Issue #95
+  - On 401, 403 errors, Restivus should wait before sending any data
+
 ## [v0.7.0] - 2015-06-18
 
 **_WARNING!_ Potentially breaking changes! Please be aware when upgrading!**

--- a/lib/route.coffee
+++ b/lib/route.coffee
@@ -205,8 +205,10 @@ class @Route
         body = JSON.stringify body
 
     # Send response
-    endpointContext.response.writeHead statusCode, headers
-    endpointContext.response.write body
+    sendResponse = ->
+      endpointContext.response.writeHead statusCode, headers
+      endpointContext.response.write body
+      endpointContext.response.end()
     if statusCode in [401, 403]
       # Hackers can measure the response time to determine things like whether the 401 response was 
       # caused by bad user id vs bad password.
@@ -217,9 +219,9 @@ class @Route
       minimumDelayInMilliseconds = 500
       randomMultiplierBetweenOneAndTwo = 1 + Math.random()
       delayInMilliseconds = minimumDelayInMilliseconds * randomMultiplierBetweenOneAndTwo
-      Meteor.setTimeout endpointContext.response.end, delayInMilliseconds
+      Meteor.setTimeout sendResponse, delayInMilliseconds
     else
-      endpointContext.response.end()
+      sendResponse()
 
   ###
     Return the object with all of the keys converted to lowercase


### PR DESCRIPTION
- Move the response code to a closure, and delay it if responding to a 401 or 403 error
- Resolve #95

This is a continuation of #96 