### PR TITLE
Explicitly use underscore and mongo in onTest

### DIFF
--- a/package.js
+++ b/package.js
@@ -34,8 +34,10 @@ Package.onTest(function (api) {
   api.use('nimble:restivus');
   api.use('http');
   api.use('coffeescript');
+  api.use('underscore');
   api.use('accounts-base');
   api.use('accounts-password');
+  api.use('mongo')
 
   api.addFiles('test/api_tests.coffee', 'server');
   api.addFiles('test/route_unit_tests.coffee', 'server');


### PR DESCRIPTION
Fixes test failure under Meteor 1.2.0.2