### PR TITLE
fixed - parse error on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -889,7 +889,7 @@ Api.addRoute 'articles', {authRequired: true},
 ###### JavaScript
 ```javascript
 Api.addRoute('articles', {authRequired: true}, {
-  get: function () {
+  get: {
     authRequired: false,
     action: function () {
       // GET api/articles


### PR DESCRIPTION
In this case, the `get` method should be an `object` not a `function`