### PR TITLE
Add 'authOptional'

### DIFF
--- a/lib/route.coffee
+++ b/lib/route.coffee
@@ -193,7 +193,9 @@ class @Route
       endpointContext.user = auth.user
       endpointContext.userId = auth.user._id
       true
-    else authOptional ? true : false
+    else if authOptional
+      true
+    else false
 
 
   ###

--- a/lib/route.coffee
+++ b/lib/route.coffee
@@ -163,7 +163,9 @@ class @Route
     @returns False if authentication fails, and true otherwise
   ###
   _authAccepted: (endpointContext, endpoint) ->
-    if endpoint.authRequired
+    if endpoint.authOptional
+      @_authenticate endpointContext, true
+    else if endpoint.authRequired
       @_authenticate endpointContext
     else true
 
@@ -175,7 +177,7 @@ class @Route
 
     @returns {Boolean} True if the authentication was successful
   ###
-  _authenticate: (endpointContext) ->
+  _authenticate: (endpointContext, authOptional) ->
     # Get auth info
     auth = @api._config.auth.user.call(endpointContext)
 
@@ -191,7 +193,7 @@ class @Route
       endpointContext.user = auth.user
       endpointContext.userId = auth.user._id
       true
-    else false
+    else authOptional ? true : false
 
 
   ###


### PR DESCRIPTION
Add 'authOptional' to optionally require login auth, if user is logged in, then endpoint 'this.user' & 'this.userId' exists.
If not logged in / auth error, endpoint 'this.user' & 'this.userId' will be undefined. User is still accessible to the API but as a guest then.
This allows more granular control over custom API authentication. e.g. When querying shops by ```Shops.find()```, Members can know whether they have favorited a Shop by ```Favorites.find({shop_id: doc._id, user_id: self.userId}).count > 0``` in collection.transform, while guests will just show shop list, as ```userId``` is undefined for guests.