### PR TITLE
Add 'authOptional'

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,12 @@ object containing the following properties:
   (#authenticating). If defined, this overrides the option of the same name defined on the entire
   route.
 
+##### `authOptional`
+- _String_
+- Default: `undefined`
+- If true, this endpoint will optionally require login auth, if user is logged in, then endpoint 'user' & 'userId' exists. If not logged in / auth error, endpoint '.user' & 'userId' will be undefined. User is still accessible to the API but as a guest then. If `authRequired` is true, this setting will be overridden.
+
+
 ##### `roleRequired`
 - _String or Array of Strings_
 - Default: `undefined` (no role required)
@@ -853,8 +859,13 @@ and will get their default values from the route.
 - _String_
 - Default: [`Route.authRequired`](#authrequired-1)
 - If true, this endpoint will return a `401` if the user is not properly
-  [authenticated](#authenticating). Overrides the option of the same name defined on the entire
-  route.
+[authenticated](#authenticating). Overrides the option of the same name defined on the entire
+route.
+
+##### `authOptional`
+- _String_
+- Default: [`Route.authOptional`](#authoptional-1)
+- If true, this endpoint will optionally require login auth, if user is logged in, then endpoint 'user' & 'userId' exists. If not logged in / auth error, endpoint '.user' & 'userId' will be undefined. User is still accessible to the API but as a guest then. If `authRequired` is true, this setting will be overridden.
 
 ##### `roleRequired`
 - _String or Array of Strings_

--- a/lib/route.coffee
+++ b/lib/route.coffee
@@ -130,6 +130,13 @@ class @Route
             endpoint.authRequired = true
           else
             endpoint.authRequired = false
+
+        # Configure auth optional
+        if endpoint.authOptional is undefined
+          if @options?.authOptional
+            endpoint.authOptional = true
+          else
+            endpoint.authOptional = false
         return
     , this
     return
@@ -165,6 +172,8 @@ class @Route
   _authAccepted: (endpointContext, endpoint) ->
     if endpoint.authRequired
       @_authenticate endpointContext
+    else if endpoint.authOptional
+      @_authenticate endpointContext, true
     else true
 
 
@@ -175,7 +184,7 @@ class @Route
 
     @returns {Boolean} True if the authentication was successful
   ###
-  _authenticate: (endpointContext) ->
+  _authenticate: (endpointContext, authOptional) ->
     # Get auth info
     auth = @api._config.auth.user.call(endpointContext)
 
@@ -190,6 +199,8 @@ class @Route
     if auth?.user
       endpointContext.user = auth.user
       endpointContext.userId = auth.user._id
+      true
+    else if authOptional
       true
     else false
 


### PR DESCRIPTION
Add 'authOptional' to optionally require login auth, if user is logged in, then endpoint 'this.user' & 'this.userId' exists.
If not logged in / auth error, endpoint 'this.user' & 'this.userId' will be undefined. User is still accessible to the API but as a guest then.
This allows more granular control over custom API authentication. e.g. When querying shops by Shops.find(), Members can know whether they have favorited a Shop by Favorites.find({shop_id: doc._id, user_id: self.userId}).count > 0 in collection.transform, while guests will just show shop list, as userId is undefined for guests.
