### PR TITLE
Remove leading slashes from examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -740,14 +740,14 @@ inside of the GET endpoint function we can get the actual value of the `_id` fro
 ###### CoffeeScript:
 ```coffeescript
 # Given a URL like "/post/5"
-Api.addRoute '/post/:_id',
+Api.addRoute 'post/:_id',
   get: ->
     id = @urlParams._id # "5"
 ```
 ###### JavaScript:
 ```javascript
 // Given a URL "/post/5"
-Api.addRoute('/post/:_id', {
+Api.addRoute('post/:_id', {
   get: function () {
     var id = this.urlParams._id; // "5"
   }
@@ -761,7 +761,7 @@ parameter. If you navigate to the URL `/post/5/comments/100` then inside your en
 ###### CoffeeScript:
 ```coffeescript
 # Given a URL "/post/5/comments/100"
-Api.addRoute '/post/:_id/comments/:commentId',
+Api.addRoute 'post/:_id/comments/:commentId',
   get: ->
     id = @urlParams._id # "5"
     commentId = @urlParams.commentId # "100"
@@ -770,7 +770,7 @@ Api.addRoute '/post/:_id/comments/:commentId',
 ###### JavaScript:
 ```javascript
 // Given a URL "/post/5/comments/100"
-Api.addRoute('/post/:_id/comments/:commentId', {
+Api.addRoute('post/:_id/comments/:commentId', {
   get: function () {
     var id = this.urlParams._id; // "5"
     var commentId = this.urlParams.commentId; // "100"
@@ -783,7 +783,7 @@ If there is a query string in the URL, you can access that using `this.queryPara
 ###### Coffeescript:
 ```coffeescript
 # Given the URL: "/post/5?q=liked#hash_fragment"
-Api.addRoute '/post/:_id',
+Api.addRoute 'post/:_id',
   get: ->
     id = @urlParams._id
     query = @queryParams # query.q -> "liked"
@@ -792,7 +792,7 @@ Api.addRoute '/post/:_id',
 ###### JavaScript:
 ```javascript
 // Given the URL: "/post/5?q=liked#hash_fragment"
-Api.addRoute('/post/:_id', {
+Api.addRoute('post/:_id', {
   get: function () {
     var id = this.urlParams._id;
     var query = this.queryParams; // query.q -> "liked"


### PR DESCRIPTION
When following the examples from the `README`, code like this does not work: 

``` javascript
Api.addRoute('/Post/', {
  get: function () {
    return "Hello, World!";
  }
});
```

And removing the leading slash from `Api.addRoute('/Post/')` makes it work. 
