### PR TITLE
Update to the latest version of json-routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## Unreleased
+
+#### Changed
+- Update to the latest version of `simple:json-routes` (v2.0.1)
+  - Increases max request size to 50mb ([#78][] and [#179][]) 
+
+
 ## [v0.8.5] - 2016-02-24
 
 #### Fixed

--- a/README.md
+++ b/README.md
@@ -1128,6 +1128,8 @@ We can call our `POST /articles/:id/comments` endpoint the following way. Note t
 curl -d "message=Some message details" http://localhost:3000/api/articles/3/comments
 ```
 
+_**Note: There is a 50mb limit on requests. If you need this limit increased, please file a GitHub Issue.**_
+
 ## Authenticating
 
 **Warning: Make sure you're using HTTPS, otherwise this is insecure!**

--- a/package.js
+++ b/package.js
@@ -15,7 +15,7 @@ Package.onUse(function (api) {
   api.use('coffeescript');
   api.use('underscore');
   api.use('accounts-base@1.2.0');
-  api.use('simple:json-routes@1.0.4');
+  api.use('simple:json-routes@=2.0.1');
 
   api.addFiles('lib/auth.coffee', 'server');
   api.addFiles('lib/iron-router-error-to-response.js', 'server');


### PR DESCRIPTION
- Increases request entity size limit to 50mb
  - Fix #78 and #179