### PR TITLE
return response data from auth.user failure

### DIFF
--- a/lib/route.coffee
+++ b/lib/route.coffee
@@ -144,7 +144,9 @@ class share.Route
   ###
   _callEndpoint: (endpointContext, endpoint) ->
     # Call the endpoint if authentication doesn't fail
-    if @_authAccepted endpointContext, endpoint
+    authResult = @_authAccepted endpointContext, endpoint
+    return authResult if typeof authResult is 'object'
+    if authResult
       if @_roleAccepted endpointContext, endpoint
         endpoint.action.call endpointContext
       else
@@ -193,7 +195,8 @@ class share.Route
       endpointContext.user = auth.user
       endpointContext.userId = auth.user._id
       true
-    else false
+    else
+      if typeof auth is 'object' then auth else false
 
 
   ###


### PR DESCRIPTION
This PR adds the ability to return an object from auth.user() to be returned as data to the requester.

This allows custom status codes and messages to be sent to the user in case of authentication failure instead of the hard coded default 401 "You must be logged in to do this.". 

It passes along a standard object like this:

```
const API = new Restivus({
  apiPath: 'api/',
  version: 'v1',
  auth: {
    user(){
      if (this.request.headers.authorization === undefined){
        return {
          statusCode: 401,
          body: {
            status: 'error',
            message: 'Authorization header required.'
          }
        }
      }
      ... [rest of authentication validation]
   }
 }
```

The existing behavior still exists when either false, or a valid object with a user field present is returned.
