### PR TITLE
Adds queryParams as an option for getAll requests

### DIFF
--- a/lib/restivus.coffee
+++ b/lib/restivus.coffee
@@ -188,7 +188,7 @@ class @Restivus
     getAll: (collection) ->
       get:
         action: ->
-          entities = collection.find().fetch()
+          entities = collection.find(@queryParams).fetch()
           if entities
             {status: 'success', data: entities}
           else
@@ -242,7 +242,7 @@ class @Restivus
     getAll: (collection) ->
       get:
         action: ->
-          entities = collection.find({}, fields: profile: 1).fetch()
+          entities = collection.find(@queryParams, fields: profile: 1).fetch()
           if entities
             {status: 'success', data: entities}
           else

--- a/lib/restivus.coffee
+++ b/lib/restivus.coffee
@@ -159,8 +159,9 @@ class @Restivus
     put: (collection) ->
       put:
         action: ->
-          if @queryParams
-              entityIsUpdated = collection.update @urlParams.id, {$set: @queryParams}
+          EMPTY = {}
+          if @queryParams isnt EMPTY
+              entityIsUpdated = collection.update @urlParams.id, $set: @queryParams
           else
               entityIsUpdated = collection.update @urlParams.id, @bodyParams
           if entityIsUpdated

--- a/lib/restivus.coffee
+++ b/lib/restivus.coffee
@@ -159,8 +159,7 @@ class @Restivus
     put: (collection) ->
       put:
         action: ->
-          EMPTY = {}
-          if @queryParams isnt EMPTY
+          if not _.isEmpty(@queryParams) 
               entityIsUpdated = collection.update @urlParams.id, $set: @queryParams
           else
               entityIsUpdated = collection.update @urlParams.id, @bodyParams

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'maka:rest',
   summary: 'Create authenticated REST APIs in Meteor 0.9+ via HTTP/HTTPS. Setup CRUD endpoints for Collections.',
-  version: '0.8.13',
+  version: '0.8.18',
   git: 'https://github.com/kahmali/meteor-restivus.git'
 });
 

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'maka:rest',
   summary: 'Create authenticated REST APIs in Meteor 0.9+ via HTTP/HTTPS. Setup CRUD endpoints for Collections.',
-  version: '0.8.18',
+  version: '0.8.22',
   git: 'https://github.com/kahmali/meteor-restivus.git'
 });
 

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
-  name: 'restivus',
+  name: 'nimble:restivus',
   summary: 'Create authenticated REST APIs in Meteor 0.9+ via HTTP/HTTPS. Setup CRUD endpoints for Collections.',
-  version: '0.8.11',
+  version: '0.8.12',
   git: 'https://github.com/kahmali/meteor-restivus.git'
 });
 
@@ -14,7 +14,7 @@ Package.onUse(function (api) {
   api.use('check');
   api.use('coffeescript');
   api.use('underscore');
-  api.use('accounts-password@1.2.2');
+  api.use('accounts-password@1.2.12');
   api.use('simple:json-routes@2.1.0');
 
   api.addFiles('lib/auth.coffee', 'server');

--- a/package.js
+++ b/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  name: 'nimble:restivus',
+  name: 'restivus',
   summary: 'Create authenticated REST APIs in Meteor 0.9+ via HTTP/HTTPS. Setup CRUD endpoints for Collections.',
   version: '0.8.11',
   git: 'https://github.com/kahmali/meteor-restivus.git'
@@ -14,7 +14,7 @@ Package.onUse(function (api) {
   api.use('check');
   api.use('coffeescript');
   api.use('underscore');
-  api.use('accounts-password@1.1.4');
+  api.use('accounts-password@1.2.2');
   api.use('simple:json-routes@2.1.0');
 
   api.addFiles('lib/auth.coffee', 'server');


### PR DESCRIPTION
I noticed that queryParams was left out of the getAll request.  This will allow query parameters to either be omitted, and thus an empty object will be used (which is how it works now), or this will make a mongodb query with the supplied query params.