### PR TITLE
Go through all Auth hooks

### DIFF
--- a/lib/auth.coffee
+++ b/lib/auth.coffee
@@ -35,6 +35,40 @@ getUserQuerySelector = (user) ->
   # We shouldn't be here if the user object was properly validated
   throw new Error 'Cannot create selector from invalid user'
 
+@Auth.customAttemptLogin = (methodInvocation, methodName, methodArgs, result) ->
+  if !result
+    throw new Error('result is required')
+  # XXX A programming error in a login handler can lead to this occuring, and
+  # then we don't call onLogin or onLoginFailure callbacks. Should
+  # tryLoginMethod catch this case and turn it into an error?
+  if !result.userId and !result.error
+    throw new Error('A login method must specify a userId or an error')
+  user = undefined
+  if result.userId
+    user = Meteor.users.findOne(result.userId)
+  attempt =
+    type: result.type or 'unknown'
+    allowed: ! !(result.userId and !result.error)
+    methodName: methodName
+    methodArguments: _.toArray(methodArgs)
+  if result.error
+    attempt.error = result.error
+  if user
+    attempt.user = user
+  # _validateLogin may mutate `attempt` by adding an error and changing allowed
+  # to false, but that's the only change it can make (and the user's callbacks
+  # only get a clone of `attempt`).
+  Accounts._validateLogin methodInvocation.connection, attempt
+  if attempt.allowed
+    ret = result.options or {}
+    ret.type = attempt.type
+    Accounts._successfulLogin methodInvocation.connection, attempt
+    return ret
+  else
+    Accounts._failedLogin methodInvocation.connection, attempt
+    throw attempt.error
+  return
+
 ###
   Log a user in with their password
 ###
@@ -57,8 +91,10 @@ getUserQuerySelector = (user) ->
 
   # Authenticate the user's password
   passwordVerification = Accounts._checkPassword authenticatingUser, password
-  if passwordVerification.error
-    throw new Meteor.Error 401, 'Unauthorized'
+  passwordVerification.type = 'password';
+  preparedPassword = if _.isString(password) then {digest: SHA256(password), algorithm: 'sha-256'} else password
+
+  Auth.customAttemptLogin {connection: null}, 'login', [ {user: user, password: preparedPassword} ], passwordVerification
 
   # Add a new auth token to the user's account
   authToken = Accounts._generateStampedLoginToken()


### PR DESCRIPTION
For example, if you have enforced email verification, then you need to use validation after login. This patch adds this feature.
#162 