### PR TITLE
Fix crash if user password `bcrypt` not set in user

### DIFF
--- a/lib/auth.coffee
+++ b/lib/auth.coffee
@@ -49,10 +49,9 @@ getUserQuerySelector = (user) ->
   # Retrieve the user from the database
   authenticatingUserSelector = getUserQuerySelector(user)
   authenticatingUser = Meteor.users.findOne(authenticatingUserSelector)
-
   if not authenticatingUser
     throw new Meteor.Error 401, 'Unauthorized'
-  if not authenticatingUser.services?.password
+  if not authenticatingUser.services?.password.bcrypt
     throw new Meteor.Error 401, 'Unauthorized'
 
   # Authenticate the user's password


### PR DESCRIPTION
Please see https://github.com/kahmali/meteor-restivus/issues/300
this is a pretty urgent fix as it crashes whole Meteor server if `bcrypt` is not set. 
It may be good to wrap the `auth` "stuff" in a try catch. Sorry my `coffeescript` is not that great.